### PR TITLE
Fix importing model dependencies

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -15,6 +15,8 @@ org.ovirt.engine.api:metamodel-server:1.3.10
 org.ovirt.engine.api:metamodel-runtime:1.3.10
 org.ovirt.engine.api:metamodel-tool:1.3.10
 org.ovirt.engine.api:model:4.5.12
+org.ovirt.engine.api:model:4.5.12:jar:sources
+org.ovirt.engine.api:model:4.5.12:jar:javadoc
 "
 
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter


### PR DESCRIPTION
For ovirt-engine-api-model we are also requiring sources and javadoc
jars, which need to be mentioned separately as they are not downloaded
by default.

Signed-off-by: Martin Perina <mperina@redhat.com>
