### PR TITLE
adapt branch for engine 4.5.3.z

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -2,7 +2,7 @@
 
 # Package version is static and should be aligned with engine version that is
 # used to build maven cache
-PKG_VERSION="4.5.3"
+PKG_VERSION="4.5.3.1"
 
 # Either a branch name or a specific tag in ovirt-engine project for which
 # the maven cache is built
@@ -29,8 +29,8 @@ cd ovirt-engine
 git checkout ${ENGINE_VERSION}
 
 # Prepare the release, which contain git hash of engine commit and current date
-#PKG_RELEASE="0.$(git rev-list HEAD | wc -l).$(date +%04Y%02m%02d%02H%02M)"
-PKG_RELEASE="1"
+PKG_RELEASE="0.$(git rev-list HEAD | wc -l).$(date +%04Y%02m%02d%02H%02M)"
+#PKG_RELEASE="1"
 
 # Build engine project to download all dependencies to the local maven repo
 mvn \

--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -6,7 +6,7 @@ PKG_VERSION="4.5.3.1"
 
 # Either a branch name or a specific tag in ovirt-engine project for which
 # the maven cache is built
-ENGINE_VERSION="master"
+ENGINE_VERSION="ovirt-engine-4.5.3.z"
 
 # Additional dependencies, which are going to be added to engine and which need
 # to be included in ovirt-engine-build-dependencies, so proper build can pass

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,36 +1,25 @@
 name: build
 on:
   push:
-    branches: [main]
+    branches: [ovirt-engine-build-dependencies-4.5.3.z]
   pull_request:
-    branches: [main]
+    branches: [ovirt-engine-build-dependencies-4.5.3.z]
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: centos-stream-8
-            shortcut: cs8
-            container-name: el8stream
-          - name: centos-stream-9
-            shortcut: cs9
-            container-name: el9stream
-
-    name: ${{ matrix.name }}
+    name: centos-stream-8
 
     env:
       ARTIFACTS_DIR: exported-artifacts
 
     container:
-      image: quay.io/ovirt/buildcontainer:${{ matrix.container-name }}
+      image: quay.io/ovirt/buildcontainer:el8stream
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: ovirt/checkout-action@main
 
     - name: Perform build
       run: |


### PR DESCRIPTION
- Post release 4.5.3
- Optimize workflow for stable branch
- Build dependencies for ovirt-engine-4.5.3.z branch
