### PR TITLE
Use latest oVirt actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: ovirt/checkout-action@main
 
     - name: Perform build
       run: |
         .automation/build-rpm.sh $ARTIFACTS_DIR
 
     - name: Upload artifacts
-      uses: ovirt/upload-rpms-action@v2
+      uses: ovirt/upload-rpms-action@main
       with:
         directory: ${{ env.ARTIFACTS_DIR}}


### PR DESCRIPTION
Use latest version of oVirt actions to simplify distributing required
changes to all oVirt projects

Signed-off-by: Martin Perina <mperina@redhat.com>
