### PR TITLE
Fix setting nightly package release

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -27,10 +27,14 @@ LOCAL_MAVEN_REPO="$(pwd)/repository"
 # Fetch required engine version
 git clone https://github.com/oVirt/ovirt-engine
 cd ovirt-engine
+
+# Mark current directory as safe for git to be able to execute git commands
+git config --global --add safe.directory $(pwd)
+
 git checkout ${ENGINE_VERSION}
 
 # Prepare the release, which contain git hash of engine commit and current date
-PKG_RELEASE="0.$(git rev-list HEAD | wc -l).$(date +%04Y%02m%02d%02H%02M)"
+PKG_RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short HEAD)"
 #PKG_RELEASE="1"
 
 # Build engine project to download all dependencies to the local maven repo


### PR DESCRIPTION
1. Marks the directory. where ovirt-engine sources are checked out, as safe
for git to be able to run git commands in this directory

2. Align nightly package release content with engine

Signed-off-by: Martin Perina <mperina@redhat.com>
