### PR TITLE
Bump jackson-databind to 2.12.7.1

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -16,7 +16,7 @@ org.yaml:snakeyaml:1.33
 com.fasterxml.jackson.core:jackson-annotations:2.12.7
 com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.12.7
 com.fasterxml.jackson.core:jackson-core:2.12.7
-com.fasterxml.jackson.core:jackson-databind:2.12.7
+com.fasterxml.jackson.core:jackson-databind:2.12.7.1
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.7
 org.springframework:spring-aop:5.3.27
 org.springframework:spring-beans:5.3.27


### PR DESCRIPTION
Bumps the version to mitigate the latest CVEs.

Signed-off-by: Martin Perina <mperina@redhat.com>
