### PR TITLE
automation: fix java version in copr build

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -37,6 +37,9 @@ git checkout ${ENGINE_VERSION}
 #PKG_RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short HEAD)"
 PKG_RELEASE="1"
 
+# Set the location of the JDK that will be used for compilation:
+export JAVA_HOME="${JAVA_HOME:=/usr/lib/jvm/java-11}"
+
 # Build engine project to download all dependencies to the local maven repo
 mvn \
     clean \


### PR DESCRIPTION
Force setting JAVA_HOME to java11 to make sure copr builds work. This because java17 is selected otherwise for building the srpm.

After this change my test build works:
https://copr.fedorainfracloud.org/coprs/dupondje/ovirt-master-snapshot/build/8222613/