### PR TITLE
Move maven dependency get into spec

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -21,17 +21,16 @@ ARTIFACTS_DIR=${1:-exported-artifacts}
 LOCAL_MAVEN_REPO="$(pwd)/repository"
 
 
+[ -d ${LOCAL_MAVEN_REPO} ] || mkdir -p ${LOCAL_MAVEN_REPO}
 [ -d ${ARTIFACTS_DIR} ] || mkdir -p ${ARTIFACTS_DIR}
 [ -d rpmbuild/SOURCES ] || mkdir -p rpmbuild/SOURCES
 
 # Fetch required engine version
-git clone https://github.com/oVirt/ovirt-engine
+git clone --depth=1 --branch=${ENGINE_VERSION} https://github.com/oVirt/ovirt-engine
 cd ovirt-engine
 
 # Mark current directory as safe for git to be able to execute git commands
 git config --global --add safe.directory $(pwd)
-
-git checkout ${ENGINE_VERSION}
 
 # Prepare the release, which contain git hash of engine commit and current date
 PKG_RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short HEAD)"
@@ -40,46 +39,13 @@ PKG_RELEASE="0.$(date +%04Y%02m%02d%02H%02M).git$(git rev-parse --short HEAD)"
 # Set the location of the JDK that will be used for compilation:
 export JAVA_HOME="${JAVA_HOME:=/usr/lib/jvm/java-11}"
 
-# Build engine project to download all dependencies to the local maven repo
-mvn \
-    clean \
-    install \
-    -P gwt-admin \
-    --no-transfer-progress \
-    -Dgwt.userAgent=gecko1_8 \
-    -Dgwt.compiler.localWorkers=1 \
-    -Dgwt.jvmArgs='-Xms1G -Xmx3G' \
-    -Dmaven.repo.local=${LOCAL_MAVEN_REPO}
-
-# Install additional dependencies
-for dep in ${ADDITIONAL_DEPENDENCIES} ; do
-    mvn dependency:get -Dartifact=${dep} -Dmaven.repo.local=${LOCAL_MAVEN_REPO}
-done
-
 # Archive the fetched repository without artifacts produced as a part of engine build
 cd ${LOCAL_MAVEN_REPO}/..
 
-rm -rf repository/org/ovirt/engine/api/common-parent
-rm -rf repository/org/ovirt/engine/api/interface
-rm -rf repository/org/ovirt/engine/api/interface-common-jaxrs
-rm -rf repository/org/ovirt/engine/api/restapi-apidoc
-rm -rf repository/org/ovirt/engine/api/restapi-definition
-rm -rf repository/org/ovirt/engine/api/restapi-jaxrs
-rm -rf repository/org/ovirt/engine/api/restapi-parent
-rm -rf repository/org/ovirt/engine/api/restapi-types
-rm -rf repository/org/ovirt/engine/api/restapi-webapp
-rm -rf repository/org/ovirt/engine/build-tools-root
-rm -rf repository/org/ovirt/engine/checkstyles
-rm -rf repository/org/ovirt/engine/core
-rm -rf repository/org/ovirt/engine/engine-server-ear
-rm -rf repository/org/ovirt/engine/extension
-rm -rf repository/org/ovirt/engine/make
-rm -rf repository/org/ovirt/engine/ovirt-checkstyle-extension
-rm -rf repository/org/ovirt/engine/ovirt-findbugs-filters
-rm -rf repository/org/ovirt/engine/root
-rm -rf repository/org/ovirt/engine/ui
+# Save additional deps in a file
+echo ${ADDITIONAL_DEPENDENCIES} > ADDITIONAL_DEPENDENCIES
 
-tar czf rpmbuild/SOURCES/ovirt-engine-build-dependencies-${PKG_VERSION}.tar.gz repository
+tar czf rpmbuild/SOURCES/ovirt-engine-build-dependencies-${PKG_VERSION}.tar.gz ADDITIONAL_DEPENDENCIES repository ovirt-engine
 
 # Set version and release
 sed \

--- a/ovirt-engine-build-dependencies.spec.in
+++ b/ovirt-engine-build-dependencies.spec.in
@@ -10,6 +10,8 @@ Source0:	%{name}-%{version}.tar.gz
 BuildArch:	noarch
 
 BuildRequires:	tar
+BuildRequires:	maven
+BuildRequires:	java-11-openjdk-devel
 
 Requires:	javapackages-filesystem
 
@@ -18,14 +20,55 @@ Requires:	javapackages-filesystem
 %{name} provides build dependencies for oVirt Engine, so it is possible to build it without internet access.
 
 
-
 %prep
-%setup -c -q -T
+%setup -c -q
+
+
+%build
+%global _repository %{_builddir}/%{name}-%{version}/repository
+
+# Build engine project to download all dependencies to the local maven repo
+cd %{_builddir}/%{name}-%{version}/ovirt-engine
+mvn \
+    clean \
+    install \
+    -P gwt-admin \
+    --no-transfer-progress \
+    -Dgwt.userAgent=gecko1_8 \
+    -Dgwt.compiler.localWorkers=1 \
+    -Dgwt.jvmArgs='-Xms1G -Xmx3G' \
+    -Dmaven.repo.local=%{_repository}
+
+# Install additional dependencies
+cd %{_builddir}/%{name}-%{version}
+for dep in %(cat ADDITIONAL_DEPENDENCIES); do
+    mvn dependency:get -Dartifact=${dep} -Dmaven.repo.local=%{_repository}
+done
+
+rm -rf %{_repository}/org/ovirt/engine/api/common-parent
+rm -rf %{_repository}/org/ovirt/engine/api/interface
+rm -rf %{_repository}/org/ovirt/engine/api/interface-common-jaxrs
+rm -rf %{_repository}/org/ovirt/engine/api/restapi-apidoc
+rm -rf %{_repository}/org/ovirt/engine/api/restapi-definition
+rm -rf %{_repository}/org/ovirt/engine/api/restapi-jaxrs
+rm -rf %{_repository}/org/ovirt/engine/api/restapi-parent
+rm -rf %{_repository}/org/ovirt/engine/api/restapi-types
+rm -rf %{_repository}/org/ovirt/engine/api/restapi-webapp
+rm -rf %{_repository}/org/ovirt/engine/build-tools-root
+rm -rf %{_repository}/org/ovirt/engine/checkstyles
+rm -rf %{_repository}/org/ovirt/engine/core
+rm -rf %{_repository}/org/ovirt/engine/engine-server-ear
+rm -rf %{_repository}/org/ovirt/engine/extension
+rm -rf %{_repository}/org/ovirt/engine/make
+rm -rf %{_repository}/org/ovirt/engine/ovirt-checkstyle-extension
+rm -rf %{_repository}/org/ovirt/engine/ovirt-findbugs-filters
+rm -rf %{_repository}/org/ovirt/engine/root
+rm -rf %{_repository}/org/ovirt/engine/ui
 
 
 %install
-install -d -m 755  %{buildroot}%{_datadir}/%{name}/repository
-tar -xf %{SOURCE0} -C %{buildroot}%{_datadir}/%{name}
+install -d -m 755 %{buildroot}%{_datadir}/%{name}
+cp -a repository %{buildroot}%{_datadir}/%{name}/
 
 
 %files


### PR DESCRIPTION
Moving the mvn calls into the spec file instead of the srpm creation. This because the srpm is not always created with the same OS (version) as the ovirt-engine build. For example on COPR the srpm is created on Fedora, and this causes issues when generating the maven dependencies. Resulting in missing dependencies when building ovirt-engine on the c9s chroot.


Test build on Copr successful: https://copr.fedorainfracloud.org/coprs/dupondje/ovirt-master-snapshot/build/8246247/