### PR TITLE
Bump jsass to 5.11.1

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -12,6 +12,7 @@ ENGINE_VERSION="master"
 # to be included in ovirt-engine-build-dependencies, so proper build can pass
 ADDITIONAL_DEPENDENCIES="
 com.puppycrawl.tools:checkstyle:10.20.0
+io.bit3:jsass:5.11.1
 "
 
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter


### PR DESCRIPTION
Add dependency new version to make CI for ovirt-engine worked.

Bumps the version for possibility of local work on the arm(e.g. on mac's with arm processors)