### PR TITLE
Depend on maven-openjdk11

### DIFF
--- a/ovirt-engine-build-dependencies.spec.in
+++ b/ovirt-engine-build-dependencies.spec.in
@@ -11,6 +11,7 @@ BuildArch:	noarch
 
 BuildRequires:	tar
 BuildRequires:	maven
+BuildRequires:	maven-openjdk11
 BuildRequires:	java-11-openjdk-devel
 
 Requires:	javapackages-filesystem


### PR DESCRIPTION
The default JDK version changed to Java 17.
Add an explicit depend on maven-openjdk11 to use java11.