### PR TITLE
Bump org.codehaus.mojo:jaxb2-maven-plugin to 3.1.0

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -13,6 +13,7 @@ ENGINE_VERSION="master"
 ADDITIONAL_DEPENDENCIES="
 com.puppycrawl.tools:checkstyle:10.20.0
 io.bit3:jsass:5.11.1
+org.codehaus.mojo:jaxb2-maven-plugin:3.1.0
 "
 
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter


### PR DESCRIPTION
Change to 3.1.0 version of jaxb2-maven-plugin.
This version was already used in ovirt-engine but incorrectly referenced.