### PR TITLE
build: modify commons-codec/io/compress/lang3

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -26,10 +26,10 @@ com.ongres.stringprep:saslprep:1.1
 com.ongres.stringprep:stringprep:1.1
 com.ongres.scram:common:2.1
 com.ongres.scram:client:2.1
-commons-codec:commons-codec:1.17.1
-commons-io:commons-io:2.16.1
-org.apache.commons:commons-compress:1.27.1
-org.apache.commons:commons-lang3:3.14.0
+commons-codec:commons-codec:1.15
+commons-io:commons-io:2.8.0
+org.apache.commons:commons-compress:1.21
+org.apache.commons:commons-lang3:3.12.0
 "
 
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter


### PR DESCRIPTION
Prepare for version change of:
commons-codec:commons-codec
commons-io:commons-io
org.apache.commons:commons-compress
org.apache.commons:commons-lang3

This as we need to build on the oldest version available on CentOS 9 or CentOS 10.